### PR TITLE
Make anti-missile turrets shoot nearer projectiles first

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2035,7 +2035,7 @@ void Engine::DoAntiMissile(Ship *ship)
 	for(std::vector<Projectile>::iterator iter = projectiles.begin(); iter < projectiles.end(); iter++)
 	{
 		std::vector<Projectile>::iterator copy_iter(iter);
-		sorted_projectiles.push_back(iter);
+		sorted_projectiles.push_back(copy_iter);
 	}
 	std::sort(sorted_projectiles.begin(),sorted_projectiles.end(),
 			[ship](std::vector<Projectile>::iterator i, std::vector<Projectile>::iterator j) -> bool

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2046,10 +2046,7 @@ void Engine::DoAntiMissile(Ship *ship)
 	{
 		if(projectile->MissileStrength() && (ship == projectile->Target() || projectile->GetGovernment()->IsEnemy(ship->GetGovernment())))
 			if(ship->FireAntiMissile(*projectile, visuals))
-			{
 				projectile->Kill();
-				break;
-			}
 	}
 }
 

--- a/source/Engine.h
+++ b/source/Engine.h
@@ -107,6 +107,7 @@ private:
 	void FillCollisionSets();
 	
 	void DoCollisions(Projectile &projectile);
+	void DoAntiMissile(Ship* ship);
 	void DoWeather(Weather &weather);
 	void DoCollection(Flotsam &flotsam);
 	void DoScanning(const std::shared_ptr<Ship> &ship);


### PR DESCRIPTION
## Feature
This PR changes anti-missile targeting behavior so that anti-missile turrets always target the closest enemy missile.

The current prioritization, which I believe implicitly targeted the oldest projectile first, looks like this:
https://user-images.githubusercontent.com/547660/128966896-044a3f09-9087-4b2d-b521-41bded67f971.mp4

The prioritization implemented here looks like this (note how the closest mines are targeted first):
https://user-images.githubusercontent.com/547660/128966907-1f5afb45-dff1-42ab-bdf4-e53e45fce147.mp4

## Feature Details
To do this, I pulled the anti-missile targeting code out of the collision detection function and put it in its own function. Each time the function runs, it needs to create a new list of projectiles sorted by each projectile's distance from the ship.

In order to avoid sorting the actual global list of projectiles and potentially creating side effects, I used a list of pointers to create a sorting order on top of the projectiles. There may be a better solution. This solution certainly *looks* ugly to me.

## Testing Done
I've played the old and new code and observed ships (both player and NPC) with multiple anti-missile turrets reacting to a variety of missiles to verify that anti-missile turrets still function and that no crashes occur.

## Save File
This save file can be used to test the behavior:
[AntiMissilePriorityTest.txt](https://github.com/endless-sky/endless-sky/files/6965755/AntiMissilePriorityTest.txt)

The player's ship in this save file has extra hit points, multiple anti-missile turrets, and a cloaking device. You can either cloak and watch how Sestor anti-missiles interact with Mereti mines, or you can fly through the minefields yourself to see how it looks from the player's perspective.

## Performance Impact
In order to find the nearest projectiles, the engine needs to sort the entire list of projectiles once for each ship that has anti-missile turrets, which is a O(n^2 log n) when merely iterating arbitrarily through the ships once for each projectile was O(n^2). This could cause a loss of performance in systems with large numbers of projectiles and anti-missile-equipped ships. (I did not notice any loss of performance on my machine in Mesuket, one of the busier systems in the game.)